### PR TITLE
Bump Ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Alice Kaerast
 
-FROM ruby:2.5.1-alpine3.7
+FROM ruby:2.7.1-alpine
 
 RUN apk --update --no-cache add --virtual build_deps build-base ruby-dev libc-dev linux-headers shadow su-exec \
     && gem install --verbose --no-document bundler \


### PR DESCRIPTION
Latest Ruby = Latest Bundler

So in our case, it fixes this:

```
✔ Strawb@MacBook:~/git_src/github.com/skybet/skybet.github.io  [master|✔]
16:16 $ staticli rake
INFO[0000] Using Tag latest
INFO[0000] Serving http on port 2000 - http://127.0.0.1:2000
You must use Bundler 2 or greater with this lockfile.
You must use Bundler 2 or greater with this lockfile.
```